### PR TITLE
Balance nodes equally by test count.

### DIFF
--- a/noseparallel/plugin.py
+++ b/noseparallel/plugin.py
@@ -1,6 +1,7 @@
-import os
-import logging
 from nose.plugins.base import Plugin
+from operator import itemgetter
+import logging
+import os
 
 log = logging.getLogger('nose.plugin.parallel')
 
@@ -25,7 +26,9 @@ class ParallelPlugin(Plugin):
         return None
 
     def _pick_by_hash(self, name):
-        class_numeric_id = abs(hash(name))
-        if class_numeric_id % self.total_nodes == self.node_index:
+        node_loads = [int(os.environ.get("NODE_LOAD_%d" % i)) or 0 for i in xrange(self.total_nodes)]
+        min_load_index = min(enumerate(node_loads), key=itemgetter(1))[0]
+        os.environ['NODE_LOAD_%d' % min_load_index] = str(int(os.environ.get("NODE_LOAD_%d" % i)) + 1)
+        if min_load_index == self.node_index:
             return True
         return False

--- a/noseparallel/plugin.py
+++ b/noseparallel/plugin.py
@@ -12,6 +12,8 @@ class ParallelPlugin(Plugin):
         super(ParallelPlugin, self).configure(options, config)
         self.total_nodes = int(os.environ.get('CIRCLE_NODE_TOTAL') or os.environ.get('NODE_TOTAL', 1))
         self.node_index = int(os.environ.get('CIRCLE_NODE_INDEX') or os.environ.get('NODE_INDEX', 0))
+        for i in xrange(self.total_nodes):
+            os.environ['NODE_LOAD_%d' % i] = str(0)
 
     def wantMethod(self, method):
         if not method.__name__.lower().startswith("test"):
@@ -26,9 +28,9 @@ class ParallelPlugin(Plugin):
         return None
 
     def _pick_by_hash(self, name):
-        node_loads = [int(os.environ.get("NODE_LOAD_%d" % i)) or 0 for i in xrange(self.total_nodes)]
+        node_loads = [(int(os.environ.get("NODE_LOAD_%d" % i)) or 0) for i in xrange(self.total_nodes)]
         min_load_index = min(enumerate(node_loads), key=itemgetter(1))[0]
-        os.environ['NODE_LOAD_%d' % min_load_index] = str(int(os.environ.get("NODE_LOAD_%d" % i)) + 1)
+        os.environ['NODE_LOAD_%d' % min_load_index] = str(node_loads[min_load_index] + 1)
         if min_load_index == self.node_index:
             return True
         return False

--- a/noseparallel/plugin.py
+++ b/noseparallel/plugin.py
@@ -30,7 +30,7 @@ class ParallelPlugin(Plugin):
     def _pick_by_hash(self, name):
         # Distribute the load evenly. Every node gets the same
         #   number of tests.
-        node_loads = [(int(os.environ.get("NODE_LOAD_%d" % i)) or 0) for i in xrange(self.total_nodes)]
+        node_loads = [int(os.environ.get("NODE_LOAD_%d" % i)) or 0 for i in xrange(self.total_nodes)]
         min_load_index = min(enumerate(node_loads), key=itemgetter(1))[0]
         os.environ['NODE_LOAD_%d' % min_load_index] = str(node_loads[min_load_index] + 1)
         if min_load_index == self.node_index:

--- a/noseparallel/plugin.py
+++ b/noseparallel/plugin.py
@@ -28,6 +28,8 @@ class ParallelPlugin(Plugin):
         return None
 
     def _pick_by_hash(self, name):
+        # Distribute the load evenly. Every node gets the same
+        #   number of tests.
         node_loads = [(int(os.environ.get("NODE_LOAD_%d" % i)) or 0) for i in xrange(self.total_nodes)]
         min_load_index = min(enumerate(node_loads), key=itemgetter(1))[0]
         os.environ['NODE_LOAD_%d' % min_load_index] = str(node_loads[min_load_index] + 1)


### PR DESCRIPTION
#### What

This pull request alters the parallelization plugin to equally distribute tests across nodes.
#### Why

Currently, we distribute tests to nodes by taking a hash modulo the number of nodes. Unfortunately, our test suite is such that they don't distribute very evenly. Here is a sample run with this method:

```
# node | test count | run time |
#    0 |        194 |  864.688 |
#    1 |        220 |  970.17  |
#    2 |        203 |  839.499 |
#    3 |        176 |  752.482 |
#    4 |        193 |  686.05  |
#    5 |        194 |  741.193 |
#    6 |        198 |  638.144 |
#    7 |        165 |  635.68  |
#    8 |        199 |  637.312 |
#    9 |        207 |  916.756 |
#   10 |        165 |  576.839 |
#   11 |        196 |  763.223 |

mean run time = 751.836
```

The fastest node has the least number of tests. The slowest test has the most. While this doesn't always hold true (compare node 5 to node 6), in general, more tests takes longer to run than less tests.

Here is a [sample run](https://circleci.com/gh/TriggerMail/trigger_mail/37646#build-timing) with an equal spread:

```
# node | test count | run time |
#    0 |        193 |  859.026 |
#    1 |        193 |  731.86  |
#    2 |        193 |  695.848 |
#    3 |        193 |  759.475 |
#    4 |        193 |  751.733 |
#    5 |        193 |  715.362 |
#    6 |        193 |  743.32  |
#    7 |        192 |  738.143 |
#    8 |        192 |  721.557 |
#    9 |        192 |  740.103 |
#   10 |        191 |  856.033 |
#   11 |        190 |  890.618 |

mean run time = 766.923
```

Despite a slightly higher average run time, the deviation from that average is smaller. This helps us produce a more even build and shorter run time.

<img width="1165" alt="screen shot 2016-06-07 at 9 47 31 pm" src="https://cloud.githubusercontent.com/assets/1433662/15880247/8634cd0a-2cf9-11e6-8ba7-9bbb3cb3001e.png">
#### What's Next

To further optimize this, we can distribute tests based on their previous run times. A greedy approach should do pretty well.
